### PR TITLE
app.yamlのruntimeをnodejs16からnodejs20に変更

### DIFF
--- a/simple-sns-api/app.yaml
+++ b/simple-sns-api/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs16
+runtime: nodejs20
 instance_class: F4
 
 env_variables:


### PR DESCRIPTION
# 発生したエラー

#22 のPRをマージ後、デプロイ処理が走ったが下のようなエラーが出た。

https://github.com/anycloud-inc/simple-sns-api/actions/runs/8629450725/job/23653685385
![image](https://github.com/anycloud-inc/simple-sns-api/assets/135786069/f8ebd499-b80c-475a-93be-5ca3ef74c3b1)

# 原因

Google Cloud App EngineがNode.js16のバージョンのサポートを終了したため。

# 解決策

simple-sns-api/app.yaml のruntime:をnodejs16からnodejs20に変更した。

# なぜnodejs20にしたか?

LTS版が`v20.12.2`と`v18.20.2`の二つがあった。なるだけ新しい方がいいだろうと思ったから、とりあえず20にした。また、この変更によってデプロイ時に出るコンソールが変わると思うので、エラーが出たら`v18.20.2`に変更することも検討している。

https://nodejs.org/en/download

![スクリーンショット 2024-04-11 115854](https://github.com/anycloud-inc/simple-sns-api/assets/135786069/0bc091cd-2ddd-4ec9-9d85-53de26b70cbb)

# 備考

このエラーに関するSlackのスレッドを貼っておきます。

https://anycloud-training.slack.com/archives/C06NV30B25U/p1712797881128069